### PR TITLE
Fix config tests to properly handle HARDCOVER_API_KEY environment variable

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -15,6 +15,11 @@ import (
 )
 
 func TestConfigSetAPIKeyCmd_Success(t *testing.T) {
+	// Unset environment variable for this test
+	oldAPIKey := os.Getenv("HARDCOVER_API_KEY")
+	os.Unsetenv("HARDCOVER_API_KEY")
+	defer os.Setenv("HARDCOVER_API_KEY", oldAPIKey)
+
 	// Create temporary directory for config
 	tempDir := t.TempDir()
 
@@ -64,6 +69,11 @@ func TestConfigSetAPIKeyCmd_RequiresArgument(t *testing.T) {
 }
 
 func TestConfigGetAPIKeyCmd_WithAPIKey(t *testing.T) {
+	// Unset environment variable for this test
+	oldAPIKey := os.Getenv("HARDCOVER_API_KEY")
+	os.Unsetenv("HARDCOVER_API_KEY")
+	defer os.Setenv("HARDCOVER_API_KEY", oldAPIKey)
+
 	// Create temporary directory for config
 	tempDir := t.TempDir()
 
@@ -159,6 +169,11 @@ func TestConfigGetAPIKeyCmd_NoAPIKey(t *testing.T) {
 }
 
 func TestConfigGetAPIKeyCmd_ShortAPIKey(t *testing.T) {
+	// Unset environment variable for this test
+	oldAPIKey := os.Getenv("HARDCOVER_API_KEY")
+	os.Unsetenv("HARDCOVER_API_KEY")
+	defer os.Setenv("HARDCOVER_API_KEY", oldAPIKey)
+
 	// Create temporary directory for config
 	tempDir := t.TempDir()
 
@@ -192,6 +207,11 @@ func TestConfigGetAPIKeyCmd_ShortAPIKey(t *testing.T) {
 }
 
 func TestConfigShowPathCmd_Success(t *testing.T) {
+	// Unset environment variable for this test
+	oldAPIKey := os.Getenv("HARDCOVER_API_KEY")
+	os.Unsetenv("HARDCOVER_API_KEY")
+	defer os.Setenv("HARDCOVER_API_KEY", oldAPIKey)
+
 	// Create temporary directory for config
 	tempDir := t.TempDir()
 
@@ -219,6 +239,11 @@ func TestConfigShowPathCmd_Success(t *testing.T) {
 }
 
 func TestConfigShowPathCmd_FileExists(t *testing.T) {
+	// Unset environment variable for this test
+	oldAPIKey := os.Getenv("HARDCOVER_API_KEY")
+	os.Unsetenv("HARDCOVER_API_KEY")
+	defer os.Setenv("HARDCOVER_API_KEY", oldAPIKey)
+
 	// Create temporary directory for config
 	tempDir := t.TempDir()
 
@@ -319,6 +344,11 @@ func TestConfigCmd_Integration(t *testing.T) {
 }
 
 func TestConfigSetAPIKeyCmd_UpdatesExistingConfig(t *testing.T) {
+	// Unset environment variable for this test
+	oldAPIKey := os.Getenv("HARDCOVER_API_KEY")
+	os.Unsetenv("HARDCOVER_API_KEY")
+	defer os.Setenv("HARDCOVER_API_KEY", oldAPIKey)
+
 	// Create temporary directory for config
 	tempDir := t.TempDir()
 


### PR DESCRIPTION
## Fix config tests to properly handle HARDCOVER_API_KEY environment variable

### Problem
The config tests were failing when the `HARDCOVER_API_KEY` environment variable was set globally, as some tests expected it to be unset.

### Solution
- Added environment variable cleanup in tests that don't expect it to be set
- Ensure tests properly unset `HARDCOVER_API_KEY` before running
- Restore original environment variable value after each test using `defer`

### Changes
- Modified `cmd/config_test.go` to properly handle environment variable state
- Added cleanup code to 7 test functions that were affected
- Tests now properly isolate their environment variable state

### Testing
- All tests now pass regardless of whether `HARDCOVER_API_KEY` is set globally
- Tests maintain proper isolation and don't interfere with each other
- Environment variable state is properly restored after each test

Fixes test failures when `HARDCOVER_API_KEY` is set globally. 