### PR TITLE
fix: isolate config tests from environment variables

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -15,13 +15,9 @@ import (
 )
 
 func TestConfigSetAPIKeyCmd_Success(t *testing.T) {
-	// Setup environment and temp directory
-	envMgr := testutil.NewEnvironmentManager(t)
-	defer envMgr.Cleanup()
-	envMgr.UnsetEnv("HARDCOVER_API_KEY")
-
-	tempDirMgr := testutil.NewTempDirManager(t)
-	defer tempDirMgr.Cleanup()
+	// Setup config test manager
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
 
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
@@ -40,7 +36,7 @@ func TestConfigSetAPIKeyCmd_Success(t *testing.T) {
 	assert.Contains(t, outputStr, "Configuration file:")
 
 	// Verify config file was created and contains correct data
-	configPath := tempDirMgr.GetConfigPath()
+	configPath := ctm.GetConfigPath()
 	_, err = os.Stat(configPath)
 	require.NoError(t, err)
 
@@ -64,20 +60,16 @@ func TestConfigSetAPIKeyCmd_RequiresArgument(t *testing.T) {
 }
 
 func TestConfigGetAPIKeyCmd_WithAPIKey(t *testing.T) {
-	// Setup environment and temp directory
-	envMgr := testutil.NewEnvironmentManager(t)
-	defer envMgr.Cleanup()
-	envMgr.UnsetEnv("HARDCOVER_API_KEY")
-
-	tempDirMgr := testutil.NewTempDirManager(t)
-	defer tempDirMgr.Cleanup()
+	// Setup config test manager
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
 
 	// Create config with API key
 	cfg := &testutil.Config{
 		APIKey:  "test-api-key-123456789",
 		BaseURL: "https://api.hardcover.app/v1/graphql",
 	}
-	tempDirMgr.CreateConfig(t, cfg)
+	ctm.CreateConfig(cfg)
 
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
@@ -97,15 +89,12 @@ func TestConfigGetAPIKeyCmd_WithAPIKey(t *testing.T) {
 }
 
 func TestConfigGetAPIKeyCmd_WithEnvironmentVariable(t *testing.T) {
-	// Setup environment and temp directory
-	envMgr := testutil.NewEnvironmentManager(t)
-	defer envMgr.Cleanup()
+	// Setup config test manager
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
 
 	expectedAPIKey := "env-api-key-123456789"
-	envMgr.SetEnv("HARDCOVER_API_KEY", expectedAPIKey)
-
-	tempDirMgr := testutil.NewTempDirManager(t)
-	defer tempDirMgr.Cleanup()
+	ctm.SetEnv("HARDCOVER_API_KEY", expectedAPIKey)
 
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
@@ -125,13 +114,9 @@ func TestConfigGetAPIKeyCmd_WithEnvironmentVariable(t *testing.T) {
 }
 
 func TestConfigGetAPIKeyCmd_NoAPIKey(t *testing.T) {
-	// Setup environment and temp directory
-	envMgr := testutil.NewEnvironmentManager(t)
-	defer envMgr.Cleanup()
-	envMgr.UnsetEnv("HARDCOVER_API_KEY")
-
-	tempDirMgr := testutil.NewTempDirManager(t)
-	defer tempDirMgr.Cleanup()
+	// Setup config test manager
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
 
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
@@ -152,20 +137,16 @@ func TestConfigGetAPIKeyCmd_NoAPIKey(t *testing.T) {
 }
 
 func TestConfigGetAPIKeyCmd_ShortAPIKey(t *testing.T) {
-	// Setup environment and temp directory
-	envMgr := testutil.NewEnvironmentManager(t)
-	defer envMgr.Cleanup()
-	envMgr.UnsetEnv("HARDCOVER_API_KEY")
-
-	tempDirMgr := testutil.NewTempDirManager(t)
-	defer tempDirMgr.Cleanup()
+	// Setup config test manager
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
 
 	// Create config with short API key
 	cfg := &testutil.Config{
 		APIKey:  "short",
 		BaseURL: "https://api.hardcover.app/v1/graphql",
 	}
-	tempDirMgr.CreateConfig(t, cfg)
+	ctm.CreateConfig(cfg)
 
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
@@ -184,13 +165,9 @@ func TestConfigGetAPIKeyCmd_ShortAPIKey(t *testing.T) {
 }
 
 func TestConfigShowPathCmd_Success(t *testing.T) {
-	// Setup environment and temp directory
-	envMgr := testutil.NewEnvironmentManager(t)
-	defer envMgr.Cleanup()
-	envMgr.UnsetEnv("HARDCOVER_API_KEY")
-
-	tempDirMgr := testutil.NewTempDirManager(t)
-	defer tempDirMgr.Cleanup()
+	// Setup config test manager
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
 
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
@@ -205,26 +182,22 @@ func TestConfigShowPathCmd_Success(t *testing.T) {
 
 	// Verify output
 	outputStr := output.String()
-	expectedPath := tempDirMgr.GetConfigPath()
+	expectedPath := ctm.GetConfigPath()
 	assert.Contains(t, outputStr, "Configuration file path: "+expectedPath)
 	assert.Contains(t, outputStr, "Configuration file does not exist yet")
 }
 
 func TestConfigShowPathCmd_FileExists(t *testing.T) {
-	// Setup environment and temp directory
-	envMgr := testutil.NewEnvironmentManager(t)
-	defer envMgr.Cleanup()
-	envMgr.UnsetEnv("HARDCOVER_API_KEY")
-
-	tempDirMgr := testutil.NewTempDirManager(t)
-	defer tempDirMgr.Cleanup()
+	// Setup config test manager
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
 
 	// Create config file
 	cfg := &testutil.Config{
 		APIKey:  "test-api-key",
 		BaseURL: "https://api.hardcover.app/v1/graphql",
 	}
-	tempDirMgr.CreateConfig(t, cfg)
+	ctm.CreateConfig(cfg)
 
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
@@ -239,7 +212,7 @@ func TestConfigShowPathCmd_FileExists(t *testing.T) {
 
 	// Verify output
 	outputStr := output.String()
-	expectedPath := tempDirMgr.GetConfigPath()
+	expectedPath := ctm.GetConfigPath()
 	assert.Contains(t, outputStr, "Configuration file path: "+expectedPath)
 	assert.Contains(t, outputStr, "Configuration file exists")
 	assert.NotContains(t, outputStr, "does not exist yet")
@@ -310,20 +283,16 @@ func TestConfigCmd_Integration(t *testing.T) {
 }
 
 func TestConfigSetAPIKeyCmd_UpdatesExistingConfig(t *testing.T) {
-	// Setup environment and temp directory
-	envMgr := testutil.NewEnvironmentManager(t)
-	defer envMgr.Cleanup()
-	envMgr.UnsetEnv("HARDCOVER_API_KEY")
-
-	tempDirMgr := testutil.NewTempDirManager(t)
-	defer tempDirMgr.Cleanup()
+	// Setup config test manager
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
 
 	// Create initial config
 	cfg := &testutil.Config{
 		APIKey:  "old-api-key",
 		BaseURL: "https://api.hardcover.app/v1/graphql",
 	}
-	tempDirMgr.CreateConfig(t, cfg)
+	ctm.CreateConfig(cfg)
 
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,15 +34,11 @@ func TestLoadConfig_FromEnvironment(t *testing.T) {
 }
 
 func TestLoadConfig_FromFile(t *testing.T) {
-	// Setup environment and temp directory
-	envMgr := testutil.NewEnvironmentManager(t)
-	defer envMgr.Cleanup()
-	envMgr.UnsetEnv("HARDCOVER_API_KEY")
+	// Setup config test manager
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
 
-	tempDirMgr := testutil.NewTempDirManager(t)
-	defer tempDirMgr.Cleanup()
-
-	configDir := filepath.Join(tempDirMgr.GetTempDir(), ".hardcover")
+	configDir := filepath.Join(ctm.GetTempDir(), ".hardcover")
 	configPath := filepath.Join(configDir, "config.yaml")
 
 	// Create config directory
@@ -77,13 +73,9 @@ func TestLoadConfig_NoFileExists(t *testing.T) {
 }
 
 func TestSaveConfig(t *testing.T) {
-	// Setup environment and temp directory
-	envMgr := testutil.NewEnvironmentManager(t)
-	defer envMgr.Cleanup()
-	envMgr.UnsetEnv("HARDCOVER_API_KEY")
-
-	tempDirMgr := testutil.NewTempDirManager(t)
-	defer tempDirMgr.Cleanup()
+	// Setup config test manager
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
 
 	cfg := &config.Config{
 		APIKey:  "test-api-key",
@@ -94,7 +86,7 @@ func TestSaveConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify file was created
-	configPath := tempDirMgr.GetConfigPath()
+	configPath := ctm.GetConfigPath()
 	_, err = os.Stat(configPath)
 	require.NoError(t, err)
 
@@ -150,15 +142,11 @@ base_url: https://api.hardcover.app/v1/graphql`
 }
 
 func TestLoadConfig_InvalidYAML(t *testing.T) {
-	// Setup environment and temp directory
-	envMgr := testutil.NewEnvironmentManager(t)
-	defer envMgr.Cleanup()
-	envMgr.UnsetEnv("HARDCOVER_API_KEY")
+	// Setup config test manager
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
 
-	tempDirMgr := testutil.NewTempDirManager(t)
-	defer tempDirMgr.Cleanup()
-
-	configDir := filepath.Join(tempDirMgr.GetTempDir(), ".hardcover")
+	configDir := filepath.Join(ctm.GetTempDir(), ".hardcover")
 	configPath := filepath.Join(configDir, "config.yaml")
 
 	// Create config directory

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,7 +34,11 @@ func TestLoadConfig_FromEnvironment(t *testing.T) {
 }
 
 func TestLoadConfig_FromFile(t *testing.T) {
-	// Setup temp directory
+	// Setup environment and temp directory
+	envMgr := testutil.NewEnvironmentManager(t)
+	defer envMgr.Cleanup()
+	envMgr.UnsetEnv("HARDCOVER_API_KEY")
+
 	tempDirMgr := testutil.NewTempDirManager(t)
 	defer tempDirMgr.Cleanup()
 
@@ -73,7 +77,11 @@ func TestLoadConfig_NoFileExists(t *testing.T) {
 }
 
 func TestSaveConfig(t *testing.T) {
-	// Setup temp directory
+	// Setup environment and temp directory
+	envMgr := testutil.NewEnvironmentManager(t)
+	defer envMgr.Cleanup()
+	envMgr.UnsetEnv("HARDCOVER_API_KEY")
+
 	tempDirMgr := testutil.NewTempDirManager(t)
 	defer tempDirMgr.Cleanup()
 
@@ -142,7 +150,11 @@ base_url: https://api.hardcover.app/v1/graphql`
 }
 
 func TestLoadConfig_InvalidYAML(t *testing.T) {
-	// Setup temp directory
+	// Setup environment and temp directory
+	envMgr := testutil.NewEnvironmentManager(t)
+	defer envMgr.Cleanup()
+	envMgr.UnsetEnv("HARDCOVER_API_KEY")
+
 	tempDirMgr := testutil.NewTempDirManager(t)
 	defer tempDirMgr.Cleanup()
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -348,6 +348,62 @@ func (tdm *TempDirManager) Cleanup() {
 	}
 }
 
+// ConfigTestManager combines EnvironmentManager and TempDirManager for config tests.
+type ConfigTestManager struct {
+	envMgr  *EnvironmentManager
+	tempMgr *TempDirManager
+	t       *testing.T
+}
+
+// NewConfigTestManager creates a new config test manager that handles both
+// environment variables and temp directories for config testing.
+func NewConfigTestManager(t *testing.T) *ConfigTestManager {
+	t.Helper()
+
+	envMgr := NewEnvironmentManager(t)
+	tempMgr := NewTempDirManager(t)
+
+	// Clear HARDCOVER_API_KEY by default for config tests
+	envMgr.UnsetEnv("HARDCOVER_API_KEY")
+
+	return &ConfigTestManager{
+		envMgr:  envMgr,
+		tempMgr: tempMgr,
+		t:       t,
+	}
+}
+
+// GetTempDir returns the temporary directory path.
+func (ctm *ConfigTestManager) GetTempDir() string {
+	return ctm.tempMgr.GetTempDir()
+}
+
+// GetConfigPath returns the config file path in the temp directory.
+func (ctm *ConfigTestManager) GetConfigPath() string {
+	return ctm.tempMgr.GetConfigPath()
+}
+
+// CreateConfig creates a config file in the temp directory.
+func (ctm *ConfigTestManager) CreateConfig(cfg *Config) {
+	ctm.tempMgr.CreateConfig(ctm.t, cfg)
+}
+
+// SetEnv sets an environment variable.
+func (ctm *ConfigTestManager) SetEnv(key, value string) {
+	ctm.envMgr.SetEnv(key, value)
+}
+
+// UnsetEnv unsets an environment variable.
+func (ctm *ConfigTestManager) UnsetEnv(key string) {
+	ctm.envMgr.UnsetEnv(key)
+}
+
+// Cleanup restores all environment variables and the HOME directory.
+func (ctm *ConfigTestManager) Cleanup() {
+	ctm.envMgr.Cleanup()
+	ctm.tempMgr.Cleanup()
+}
+
 // TestCase represents a common test case structure.
 type TestCase struct {
 	Name    string


### PR DESCRIPTION
# Fix: Isolate config tests from environment variables

## Problem
The config tests were failing when `HARDCOVER_API_KEY` was set in the shell environment because `LoadConfig()` prioritizes environment variables over config files:

```go
// Environment variables override everything
if apiKey := os.Getenv("HARDCOVER_API_KEY"); apiKey != "" {
    cfg.APIKey = apiKey
    return cfg, nil
}
```

This caused tests to read actual configuration instead of test data, leading to failures like:
- Expected: `"test-api-key-from-file"` 
- Actual: `"eyJhbGciOiJIUzI1NiJ9..."` (real JWT token)

## Solution
Added `EnvironmentManager` to the failing tests to properly clear the `HARDCOVER_API_KEY` environment variable:

- **TestLoadConfig_FromFile** - Added environment manager to unset `HARDCOVER_API_KEY`
- **TestSaveConfig** - Added environment manager to unset `HARDCOVER_API_KEY`  
- **TestLoadConfig_InvalidYAML** - Added environment manager to unset `HARDCOVER_API_KEY`

## Changes
- Modified `internal/config/config_test.go` to add proper environment isolation
- Tests now properly use test data instead of reading from actual config

## Testing
- All tests now pass consistently regardless of shell environment
- Verified with `make test` and `go test ./... -count=1` 