### PR TITLE
Fix network error test reliability

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -109,8 +109,16 @@ func TestClient_Execute_HTTPError(t *testing.T) {
 }
 
 func TestClient_Execute_NetworkError(t *testing.T) {
+	// Disable proxy settings to ensure we hit the network error directly
+	t.Setenv("HTTP_PROXY", "")
+	t.Setenv("HTTPS_PROXY", "")
+	t.Setenv("http_proxy", "")
+	t.Setenv("https_proxy", "")
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
+
 	// Use invalid endpoint to trigger network error
-	c := client.NewClient("http://invalid-endpoint:99999", "test-api-key")
+	c := client.NewClient("http://localhost:0", "test-api-key")
 
 	var result map[string]interface{}
 	err := c.Execute(context.Background(), "query { test }", nil, &result)


### PR DESCRIPTION
## Summary
- isolate network error test from proxy settings

## Testing
- `go test ./... -coverprofile=coverage.out`

------
https://chatgpt.com/codex/tasks/task_b_688705dfbf9083318ceb67319d844ad4