### PR TITLE
Improve test coverage for contextutil and network error

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -109,8 +110,11 @@ func TestClient_Execute_HTTPError(t *testing.T) {
 }
 
 func TestClient_Execute_NetworkError(t *testing.T) {
-	// Use invalid endpoint to trigger network error
-	c := client.NewClient("http://invalid-endpoint:99999", "test-api-key")
+	// Start and immediately close a test server to get a valid URL that will refuse connections
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	server.Close()
+
+	c := client.NewClient(server.URL, "test-api-key")
 
 	var result map[string]interface{}
 	err := c.Execute(context.Background(), "query { test }", nil, &result)

--- a/internal/contextutil/contextutil_test.go
+++ b/internal/contextutil/contextutil_test.go
@@ -1,0 +1,38 @@
+package contextutil_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"hardcover-cli/internal/config"
+	"hardcover-cli/internal/contextutil"
+)
+
+func TestWithConfigAndGetConfig(t *testing.T) {
+	cfg := &config.Config{APIKey: "k", BaseURL: "u"}
+	ctx := context.Background()
+
+	ctx = contextutil.WithConfig(ctx, cfg)
+	got, ok := contextutil.GetConfig(ctx)
+
+	require.True(t, ok)
+	assert.Equal(t, cfg, got)
+}
+
+func TestGetConfig_NoConfig(t *testing.T) {
+	cfg, ok := contextutil.GetConfig(context.Background())
+	assert.False(t, ok)
+	assert.Nil(t, cfg)
+}
+
+func TestGetConfig_WrongType(t *testing.T) {
+	type otherKey struct{}
+	ctx := context.WithValue(context.Background(), otherKey{}, "value")
+
+	cfg, ok := contextutil.GetConfig(ctx)
+	assert.False(t, ok)
+	assert.Nil(t, cfg)
+}


### PR DESCRIPTION
## Summary
- add tests for contextutil helper functions
- update network error test to deterministically trigger connection error

## Testing
- `go test ./... -coverprofile coverage.out`

------
https://chatgpt.com/codex/tasks/task_b_688705dfbf9083318ceb67319d844ad4