### PR TITLE
Add more CLI tests

### DIFF
--- a/cmd/me_fuzz_test.go
+++ b/cmd/me_fuzz_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func FuzzPrintUserProfile(f *testing.F) {
+	seeds := []string{
+		`{"id":"1","username":"u"}`,
+		`{}`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		var user map[string]interface{}
+		_ = json.Unmarshal([]byte(input), &user)
+		var buf bytes.Buffer
+		printUserProfile(&buf, user)
+	})
+}

--- a/cmd/me_profile_test.go
+++ b/cmd/me_profile_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintUserProfile_AllFields(t *testing.T) {
+	user := map[string]interface{}{
+		"id":         "u1",
+		"username":   "tester",
+		"email":      "test@example.com",
+		"name":       "Test User",
+		"created_at": "2024-01-01",
+		"updated_at": "2024-02-01",
+	}
+
+	var buf bytes.Buffer
+	printUserProfile(&buf, user)
+
+	out := buf.String()
+	assert.Contains(t, out, "User Profile:")
+	assert.Contains(t, out, "ID: u1")
+	assert.Contains(t, out, "Username: tester")
+	assert.Contains(t, out, "Email: test@example.com")
+	assert.Contains(t, out, "Display Name: Test User")
+	assert.Contains(t, out, "Created: 2024-01-01")
+	assert.Contains(t, out, "Updated: 2024-02-01")
+}
+
+func TestPrintUserProfile_MissingFields(t *testing.T) {
+	user := map[string]interface{}{
+		"id":       "u2",
+		"username": "tester2",
+	}
+
+	var buf bytes.Buffer
+	printUserProfile(&buf, user)
+
+	out := buf.String()
+	assert.Contains(t, out, "ID: u2")
+	assert.Contains(t, out, "Username: tester2")
+	assert.NotContains(t, out, "Email:")
+	assert.NotContains(t, out, "Display Name:")
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"hardcover-cli/internal/testutil"
+)
+
+func TestInitConfig_UsesEnvVariable(t *testing.T) {
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
+
+	expected := "env-api-key"
+	ctm.SetEnv("HARDCOVER_API_KEY", expected)
+
+	if rootCmd.PersistentFlags().Lookup("api-key") == nil {
+		rootCmd.PersistentFlags().String("api-key", "", "Hardcover API key")
+	}
+	require.NoError(t, rootCmd.PersistentFlags().Set("api-key", ""))
+
+	globalConfig = nil
+	initConfig()
+
+	require.NotNil(t, globalConfig)
+	assert.Equal(t, expected, globalConfig.APIKey)
+}
+
+func TestInitConfig_FlagOverridesEnv(t *testing.T) {
+	ctm := testutil.NewConfigTestManager(t)
+	defer ctm.Cleanup()
+
+	ctm.SetEnv("HARDCOVER_API_KEY", "env-api-key")
+
+	if rootCmd.PersistentFlags().Lookup("api-key") == nil {
+		rootCmd.PersistentFlags().String("api-key", "", "Hardcover API key")
+	}
+	require.NoError(t, rootCmd.PersistentFlags().Set("api-key", "flag-api-key"))
+
+	globalConfig = nil
+	initConfig()
+
+	require.NotNil(t, globalConfig)
+	assert.Equal(t, "flag-api-key", globalConfig.APIKey)
+
+	// reset flag for other tests
+	require.NoError(t, rootCmd.PersistentFlags().Set("api-key", ""))
+}


### PR DESCRIPTION
## Summary
- test initConfig to ensure env/API flag usage
- test printUserProfile output
- fuzz printUserProfile for robustness

## Testing
- `go test ./...`
- `go test ./... -coverprofile=coverage.out`

------
https://chatgpt.com/codex/tasks/task_b_6887136f84e88331bf807d13ce5913d9